### PR TITLE
refactor(collection): make $key parameter nullable in collection macros

### DIFF
--- a/src/Macros/Collection/UniToZg.php
+++ b/src/Macros/Collection/UniToZg.php
@@ -10,7 +10,7 @@ class UniToZg
 {
     public function __invoke()
     {
-        return function (string $key = null): Collection {
+        return function (?string $key = null): Collection {
             /** @var \Illuminate\Support\Collection $this */
             return $this->map(function ($item) use ($key) {
                 if ($key) {

--- a/src/Macros/Collection/WhereMec.php
+++ b/src/Macros/Collection/WhereMec.php
@@ -10,7 +10,7 @@ class WhereMec
 {
     public function __invoke()
     {
-        return function (string $key = null): Collection {
+        return function (?string $key = null): Collection {
             /** @var \Illuminate\Support\Collection $this */
             return $this->filter(function ($item) use ($key) {
                 if ($key) {

--- a/src/Macros/Collection/WhereMpt.php
+++ b/src/Macros/Collection/WhereMpt.php
@@ -10,7 +10,7 @@ class WhereMpt
 {
     public function __invoke()
     {
-        return function (string $key = null): Collection {
+        return function (?string $key = null): Collection {
             /** @var \Illuminate\Support\Collection $this */
             return $this->filter(function ($item) use ($key) {
                 if ($key) {

--- a/src/Macros/Collection/WhereMyanmarPhoneNumber.php
+++ b/src/Macros/Collection/WhereMyanmarPhoneNumber.php
@@ -10,7 +10,7 @@ class WhereMyanmarPhoneNumber
 {
     public function __invoke()
     {
-        return function (string $key = null): Collection {
+        return function (?string $key = null): Collection {
             /** @var \Illuminate\Support\Collection $this */
             return $this->filter(function ($item) use ($key) {
                 if ($key) {

--- a/src/Macros/Collection/WhereMytel.php
+++ b/src/Macros/Collection/WhereMytel.php
@@ -10,7 +10,7 @@ class WhereMytel
 {
     public function __invoke()
     {
-        return function (string $key = null): Collection {
+        return function (?string $key = null): Collection {
             /** @var \Illuminate\Support\Collection $this */
             return $this->filter(function ($item) use ($key) {
                 if ($key) {

--- a/src/Macros/Collection/WhereOoredoo.php
+++ b/src/Macros/Collection/WhereOoredoo.php
@@ -10,7 +10,7 @@ class WhereOoredoo
 {
     public function __invoke()
     {
-        return function (string $key = null): Collection {
+        return function (?string $key = null): Collection {
             /** @var \Illuminate\Support\Collection $this */
             return $this->filter(function ($item) use ($key) {
                 if ($key) {

--- a/src/Macros/Collection/WhereTelenor.php
+++ b/src/Macros/Collection/WhereTelenor.php
@@ -10,7 +10,7 @@ class WhereTelenor
 {
     public function __invoke()
     {
-        return function (string $key = null): Collection {
+        return function (?string $key = null): Collection {
             /** @var \Illuminate\Support\Collection $this */
             return $this->filter(function ($item) use ($key) {
                 if ($key) {

--- a/src/Macros/Collection/ZgToUni.php
+++ b/src/Macros/Collection/ZgToUni.php
@@ -10,7 +10,7 @@ class ZgToUni
 {
     public function __invoke()
     {
-        return function (string $key = null): Collection {
+        return function (?string $key = null): Collection {
             /** @var \Illuminate\Support\Collection $this */
             return $this->map(function ($item) use ($key) {
                 if ($key) {


### PR DESCRIPTION
This pull request updates several collection macro classes to allow the `$key` parameter in their closures to be nullable. This improves flexibility by enabling these methods to be called without explicitly passing a key, which can simplify usage and improve compatibility with other code.

**Collection macro parameter updates:**

* Made the `$key` parameter nullable (`?string $key = null`) in the closure signatures for the following macros:
  - `UniToZg` (`src/Macros/Collection/UniToZg.php`)
  - `ZgToUni` (`src/Macros/Collection/ZgToUni.php`)
  - `WhereMec` (`src/Macros/Collection/WhereMec.php`)
  - `WhereMpt` (`src/Macros/Collection/WhereMpt.php`)
  - `WhereMyanmarPhoneNumber` (`src/Macros/Collection/WhereMyanmarPhoneNumber.php`)
  - `WhereMytel` (`src/Macros/Collection/WhereMytel.php`)
  - `WhereOoredoo` (`src/Macros/Collection/WhereOoredoo.php`)
  - `WhereTelenor` (`src/Macros/Collection/WhereTelenor.php`)